### PR TITLE
Fix add menu location

### DIFF
--- a/Source/Custom Device/Custom Device AIM MIL-STD-1553.xml
+++ b/Source/Custom Device/Custom Device AIM MIL-STD-1553.xml
@@ -2,8 +2,8 @@
 <CustomDevice xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Custom Device.xsd">
 	<XSDVersion Major="2010" Minor="0" Fix="0" Build="0" />
 	<AddMenu>
-		<eng>AIM MIL-STD-1553</eng>
-		<loc>AIM MIL-STD-1553</loc>
+		<eng>NI::AIM MIL-STD-1553</eng>
+		<loc>NI::AIM MIL-STD-1553</loc>
 	</AddMenu>
 	<Version>1.0.0</Version>
 	<Type>Inline HW Interface</Type>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-milStd1553-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Puts the custom device under the `NI` sub-menu for adding to VeriStand.

### Why should this Pull Request be merged?

The other avionics bus custom devices are added from this level.

### What testing has been done?

Manual inspection after building.
![image](https://user-images.githubusercontent.com/29306186/168658161-1e539b8d-fe9f-4c6d-a9d9-abb448d4ebec.png)

