### PR TITLE
Build custom device for 2021 64-bit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2020']
+def lvVersions = [
+  32 : ['2020'],
+  64 : ['2021']
+]
 
-diffPipeline(lvVersions[0])
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-milStd1553-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Build custom device for 2021 64-bit

### Why should this Pull Request be merged?

Allow testing with VeriStand 2021

### What testing has been done?

None; this is the same Jenkinsfile as the AIM 429 CD.