### PR TITLE
Update readme to latest format and update info on AIM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ballard MIL-STD-1553 Custom Device
+# AIM MIL-STD-1553 Custom Device
 
-The **Ballard MIL-STD-1553 Custom Device** allows use of [Astronics MIL-STD-1553 PXIe Modules with Ballard Technology](https://www.ni.com/en-us/shop/hardware/products/pxi-mil-std-1553-interface-module.html) in VeriStand. The custom device targets one **core** of a Ballard MIL-STD-1553 PXIe module. To target multiple modules or multiple cores on the same module, use multiple instances of this custom device.
+The **AIM MIL-STD-1553 Custom Device** allows use of [AIM MIL-STD-1553 PXIe Modules](https://www.ni.com/en-us/support/model.aim-mil-std-1553.html) in VeriStand. The custom device targets one **BIU** (Bus Interface Unit) of an AIM MIL-STD-1553 PXIe module. To target multiple modules or multiple BIUs on the same module, use multiple instances of this custom device.
 
 The custom device supports the following functionality:
 - Import configuration files via scripting and System Explorer
@@ -9,19 +9,29 @@ The custom device supports the following functionality:
 - Transmit and Receive configured messages, command words, and status words
    - Scheduled and Acyclic
    - Multiple parameters per message
-   - Multiple messages on one or both channels per core
+   - Multiple messages per BIU
+- Log all messages per BIU (on compatible modules)
+
+## Using the Custom Device
+
+- Download the latest release package from the [Releases page](https://github.com/ni/niveristand-aim-milStd1553-custom-device/releases).
+- See the [User Guide](Docs/User%20Guide/User%20Guide.md) for a walkthrough of using the Custom Device.
+- See the [Parameters XML File Schema documentation](Docs/Parameters%20XML%20File/Parameters%20XML%20File.md) for configuring the custom device.
 
 ## Requirements
 
 - PXI Linux RT Controller
-- Supported Ballard MIL-STD-1553 PXI Module
+- Supported AIM MIL-STD-1553 PXIe Module
 
-**Note**: Only NI-keyed PXI modules are supported by the custom device. The part number should have the form `LV-222-###-###`, where `###` stands for the core configuration. **550** and **555** core models are supported. See the mapping between NI and Ballard part numbers on [ni.com](https://www.ni.com/en-us/support/documentation/supplemental/17/astronics-ballard-and-national-instruments-part-number-mapping.html).
+### Custom Device features based on bus function
 
-## Getting Started Documentation
-
-- [User Guide](Docs/User%20Guide/User%20Guide.md)
-- [Parameters XML File Schema](Docs/Parameters%20XML%20File/Parameters%20XML%20File.md)
+| Bus Function | Single Function | Full Function |
+| --- | --- | --- |
+| Logging | Yes | Yes |
+| Simulate RTs | Yes | Yes |
+| Simulate BC | Yes | Yes |
+| Simulate BC and RTs concurrently | No | Yes |
+| Supports example assets | No | Yes |
 
 ## LabVIEW Source Code Version
 
@@ -32,14 +42,23 @@ LabVIEW 2020
 ### Running the custom device
 
 - [VeriStand 2020 or later](https://www.ni.com/ro-ro/support/downloads/software-products/download.veristand.html#382072)
-- Optional: [Astronics Ballard Avionics Driver](https://www.ni.com/en-us/support/downloads/drivers/download.astronics-ballard-avionics-driver.html#370805)
+
+### Real-Time target software components
+
+- AIM MIL-STD-1553 Board Software Package (BSP)
+  - Must enable the `ni-third-party` feed in MAX to install the `MIL-STD-1553 Board Software Package` component
 
 ### Developing or building from source
 
+- [LabVIEW 2020 or later](https://www.ni.com/en-us/support/downloads/software-products/download.labview.html)
+- [LabVIEW Real-Time Module](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html)
+- AIM MIL-STD-1553 BSP and LabVIEW API
 - [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools)
-- [NI VeriStand Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library)
-- [NI VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools)
-- [Astronics Ballard Avionics Driver and LabVIEW API](https://www.ni.com/en-us/support/downloads/drivers/download.astronics-ballard-avionics-driver.html#370805)
+  - Install the latest package from the [release page](https://github.com/ni/niveristand-custom-device-development-tools/releases)
+- [VeriStand Custom Device Message Library](https://github.com/ni/niveristand-custom-device-message-library)
+  - Install the latest package from the [release page](https://github.com/ni/niveristand-custom-device-message-library/releases)
+- [VeriStand Custom Device Testing Tools](https://github.com/ni/niveristand-custom-device-testing-tools)
+  - To link correctly, this repository should be cloned as source to the same directory level as this repository
 
 ## Git History & Rebasing Policy
 
@@ -49,4 +68,4 @@ Branch rebasing and other history modifications will be listed here, with severa
 
 ## License
 
-This Ballard MIL-STD-1553 custom device is licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.
+This AIM MIL-STD-1553 custom device is licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-milStd1553-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the readme from the (stale) copy of the Ballard one from which it was copied.
- Remove references to Ballard, replace with AIM
- Update the dependencies, useful links, etc. based on the latest Ballard readme
- Use details like the Bus Function and BIU definitions from AIM docs to update supported hardware (we are reselling the first and third set of hardware, not the -S variant)
![image](https://user-images.githubusercontent.com/31290917/172702916-bda12127-df4f-4893-ae07-9462f364d253.png)

### Why should this Pull Request be merged?

Provides accurate info, links, and removes Ballard references

### What testing has been done?

Viewed rendered markdown on github