### PR TITLE
Remove logging capability from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The custom device supports the following functionality:
    - Scheduled and Acyclic
    - Multiple parameters per message
    - Multiple messages per BIU
-- Log all messages per BIU (on compatible modules)
+<!-- - Log all messages per BIU -->
 
 ## Using the Custom Device
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-milStd1553-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove logging capability from readme by commenting it out

### Why should this Pull Request be merged?

We won't support logging for the initial release

### What testing has been done?

Previewed on github
