### PR TITLE
Use 23.0.0 dependencies

### DIFF
--- a/control_custom_device
+++ b/control_custom_device
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: AIM MIL-STD-1553 for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_scripting
+++ b/control_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: AIM MIL-STD-1553 LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
 Recommends: ni-aim-mil-std-1553-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-milStd1553-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Use the `23.0.0` version of `ni-veristand-{veristand_version}-custom-device-labview-support-common`, as there is no `21.0.0` version for VeriStand 2023.

Also remove a variable substitution which no longer works.

### Why should this Pull Request be merged?

Needed to fix the feed build.

### What testing has been done?

PR build.
